### PR TITLE
fix: clean up unused catch params

### DIFF
--- a/src/components/CommentComposer.jsx
+++ b/src/components/CommentComposer.jsx
@@ -31,7 +31,7 @@ export default function CommentComposer({
       incQuota("comments");
       setBody("");
       if (onSuccess) onSuccess();
-    } catch (err) {
+    } catch {
       setErr("Failed to post comment.");
     } finally {
       setLoading(false);

--- a/src/components/DMComposer.jsx
+++ b/src/components/DMComposer.jsx
@@ -21,7 +21,7 @@ export default function DMComposer({ toUserId, onSuccess }) {
         const { url } = await stripeAPI.createDMUnlockSession();
         window.location.href = url;
         return;
-      } catch (e) {
+      } catch {
         return setErr("Payment session failed. Try again.");
       }
     }
@@ -35,7 +35,7 @@ export default function DMComposer({ toUserId, onSuccess }) {
       if (!quota.unlimited) incQuota("dms");
       setBody("");
       if (onSuccess) onSuccess();
-    } catch (e) {
+    } catch {
       setErr("Failed to send message.");
     } finally {
       setLoading(false);

--- a/src/components/VoteWidget.jsx
+++ b/src/components/VoteWidget.jsx
@@ -32,7 +32,7 @@ export default function VoteWidget({ id }) {
     try {
       setLoading(true);
       await votesAPI.votePost(id, newVote);
-    } catch (err) {
+    } catch {
       setVote(vote); // revert
       setScore((s) => s - delta);
     } finally {

--- a/src/pages/MessagesPage.jsx
+++ b/src/pages/MessagesPage.jsx
@@ -22,7 +22,7 @@ export default function MessagesPage() {
         if (!mounted) return;
         setInbox(inboxRes.messages || []);
         setOutbox(outboxRes.messages || []);
-      } catch (e) {
+      } catch {
         setErr("Failed to load messages.");
       } finally {
         setLoading(false);

--- a/src/pages/OnboardingPage.jsx
+++ b/src/pages/OnboardingPage.jsx
@@ -46,7 +46,7 @@ export default function OnboardingPage() {
     if (!ok) return;
     try {
       await api.delete("/users/me?purge=1");
-    } catch (e) {
+    } catch {
       // fail-safe: logout regardless
     } finally {
       dispatch(logout());

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -21,7 +21,7 @@ export default function ProfilePage() {
     try {
       await api.delete("/users/me?purge=1");
       dispatch(logout());
-    } catch (e) {
+    } catch {
       alert("Delete failed.");
     }
   };

--- a/src/pages/ThreadPage.jsx
+++ b/src/pages/ThreadPage.jsx
@@ -16,7 +16,7 @@ export default function ThreadPage() {
       try {
         const res = await messagesAPI.thread(userId);
         if (mounted && res.ok) setThread(res.messages || []);
-      } catch (e) {
+      } catch {
         setErr("Failed to load thread.");
       } finally {
         setLoading(false);


### PR DESCRIPTION
## Summary
- remove unused error arguments from catch blocks across components and pages to satisfy ESLint `no-unused-vars`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6b09071f0833192e77081dcde198c